### PR TITLE
fix(merkling): Persist changed parent on save if child has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ main()
 
 ### Merkling
 
-[src/merkling.ts:18-148](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L18-L148 "Source code on GitHub")
+[src/merkling.ts:18-148](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L18-L148 "Source code on GitHub")
 
 The core IPLD access client.
 
@@ -151,7 +151,7 @@ The core IPLD access client.
 
 #### createSession
 
-[src/merkling.ts:31-33](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L31-L33 "Source code on GitHub")
+[src/merkling.ts:31-33](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L31-L33 "Source code on GitHub")
 
 Create a new merkling session to act as an
 intermediary with the IPFS node.
@@ -160,7 +160,7 @@ Returns **[MerklingSession](#merklingsession)** a new merkling session
 
 #### withSession
 
-[src/merkling.ts:42-48](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L42-L48 "Source code on GitHub")
+[src/merkling.ts:42-48](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L42-L48 "Source code on GitHub")
 
 Run an action in the form of a callback over a new session
 that is disposed of afterwards.
@@ -173,7 +173,7 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### cid
 
-[src/merkling.ts:59-69](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L59-L69 "Source code on GitHub")
+[src/merkling.ts:59-69](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L59-L69 "Source code on GitHub")
 
 Retrieve the CID for given proxy. Will returned
 undefined if the passed object is not a Merkling proxy
@@ -188,7 +188,7 @@ have a CID or null if it is currently dirty
 
 #### resolve
 
-[src/merkling.ts:78-86](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L78-L86 "Source code on GitHub")
+[src/merkling.ts:78-86](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L78-L86 "Source code on GitHub")
 
 Asynchronously force the retrieval of the state
 stored in IPFS of the IPLD block the proxy represents.
@@ -201,7 +201,7 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### inspect
 
-[src/merkling.ts:96-102](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L96-L102 "Source code on GitHub")
+[src/merkling.ts:96-102](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L96-L102 "Source code on GitHub")
 
 Retreive the stored state that the Merkling proxy
 is representing. This will include references
@@ -215,7 +215,7 @@ Returns **{}** the internal state of the IPLD block being represented
 
 #### isProxy
 
-[src/merkling.ts:111-117](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L111-L117 "Source code on GitHub")
+[src/merkling.ts:111-117](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L111-L117 "Source code on GitHub")
 
 Determine whether a given object is a tracked Merkling
 proxy.
@@ -228,7 +228,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### isIpldNode
 
-[src/merkling.ts:126-132](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L126-L132 "Source code on GitHub")
+[src/merkling.ts:126-132](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L126-L132 "Source code on GitHub")
 
 Determine whether a given object is a Merkling
 proxy representing an IPLD block.
@@ -241,7 +241,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### isDirty
 
-[src/merkling.ts:141-147](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merkling.ts#L141-L147 "Source code on GitHub")
+[src/merkling.ts:141-147](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L141-L147 "Source code on GitHub")
 
 Determine if a proxy has unsaved changes. Will
 return true if the passed object is not a proxy.
@@ -254,7 +254,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 ### MerklingSession
 
-[src/merklingSession.ts:15-258](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merklingSession.ts#L15-L258 "Source code on GitHub")
+[src/merklingSession.ts:15-290](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L15-L290 "Source code on GitHub")
 
 #### Parameters
 
@@ -263,7 +263,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### create
 
-[src/merklingSession.ts:63-94](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merklingSession.ts#L63-L94 "Source code on GitHub")
+[src/merklingSession.ts:63-94](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L63-L94 "Source code on GitHub")
 
 Create a new dirty Merkling proxy that can be manipulated
 before later being persisted.
@@ -276,7 +276,7 @@ Returns **T** a proxy representing the given state as an IPLD block
 
 #### get
 
-[src/merklingSession.ts:102-131](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merklingSession.ts#L102-L131 "Source code on GitHub")
+[src/merklingSession.ts:103-132](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L103-L132 "Source code on GitHub")
 
 Get an IPLD block from IPFS and return
 it as a tracked Merkling proxy.
@@ -285,11 +285,11 @@ it as a tracked Merkling proxy.
 
 -   `hashOrCid` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | ICid)** a CID or base encoded version
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;{}>** a clean proxy with the state loaded and accessible
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** a clean proxy with the state loaded and accessible
 
 #### load
 
-[src/merklingSession.ts:133-145](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merklingSession.ts#L133-L145 "Source code on GitHub")
+[src/merklingSession.ts:134-146](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L134-L146 "Source code on GitHub")
 
 ##### Parameters
 
@@ -299,7 +299,7 @@ Returns **IMerklingProxyState**
 
 #### save
 
-[src/merklingSession.ts:151-163](https://git@github.com/:kanej/merkling/blob/46e0188cc293ab2997b3e29e0b34956f173ad6e4/src/merklingSession.ts#L151-L163 "Source code on GitHub")
+[src/merklingSession.ts:152-164](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L152-L164 "Source code on GitHub")
 
 Save all proxies that are currently marked as dirty,
 and any proxies that depend on them.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,6 @@ main()
 
 ### Merkling
 
-[src/merkling.ts:18-148](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L18-L148 "Source code on GitHub")
-
 The core IPLD access client.
 
 #### Parameters
@@ -151,16 +149,12 @@ The core IPLD access client.
 
 #### createSession
 
-[src/merkling.ts:31-33](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L31-L33 "Source code on GitHub")
-
 Create a new merkling session to act as an
 intermediary with the IPFS node.
 
 Returns **[MerklingSession](#merklingsession)** a new merkling session
 
 #### withSession
-
-[src/merkling.ts:42-48](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L42-L48 "Source code on GitHub")
 
 Run an action in the form of a callback over a new session
 that is disposed of afterwards.
@@ -172,8 +166,6 @@ that is disposed of afterwards.
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** a promise that completes after the session action
 
 #### cid
-
-[src/merkling.ts:59-69](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L59-L69 "Source code on GitHub")
 
 Retrieve the CID for given proxy. Will returned
 undefined if the passed object is not a Merkling proxy
@@ -188,8 +180,6 @@ have a CID or null if it is currently dirty
 
 #### resolve
 
-[src/merkling.ts:78-86](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L78-L86 "Source code on GitHub")
-
 Asynchronously force the retrieval of the state
 stored in IPFS of the IPLD block the proxy represents.
 
@@ -200,8 +190,6 @@ stored in IPFS of the IPLD block the proxy represents.
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Proxy](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy)>** the given proxy now loaded and clean.
 
 #### inspect
-
-[src/merkling.ts:96-102](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L96-L102 "Source code on GitHub")
 
 Retreive the stored state that the Merkling proxy
 is representing. This will include references
@@ -215,8 +203,6 @@ Returns **{}** the internal state of the IPLD block being represented
 
 #### isProxy
 
-[src/merkling.ts:111-117](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L111-L117 "Source code on GitHub")
-
 Determine whether a given object is a tracked Merkling
 proxy.
 
@@ -227,8 +213,6 @@ proxy.
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** the answer
 
 #### isIpldNode
-
-[src/merkling.ts:126-132](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L126-L132 "Source code on GitHub")
 
 Determine whether a given object is a Merkling
 proxy representing an IPLD block.
@@ -241,8 +225,6 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### isDirty
 
-[src/merkling.ts:141-147](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merkling.ts#L141-L147 "Source code on GitHub")
-
 Determine if a proxy has unsaved changes. Will
 return true if the passed object is not a proxy.
 
@@ -254,16 +236,12 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 ### MerklingSession
 
-[src/merklingSession.ts:15-290](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L15-L290 "Source code on GitHub")
-
 #### Parameters
 
 -   `$0` **{ipfs: IIpfsNode}** 
     -   `$0.ipfs`  
 
 #### create
-
-[src/merklingSession.ts:63-94](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L63-L94 "Source code on GitHub")
 
 Create a new dirty Merkling proxy that can be manipulated
 before later being persisted.
@@ -276,8 +254,6 @@ Returns **T** a proxy representing the given state as an IPLD block
 
 #### get
 
-[src/merklingSession.ts:103-132](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L103-L132 "Source code on GitHub")
-
 Get an IPLD block from IPFS and return
 it as a tracked Merkling proxy.
 
@@ -289,8 +265,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### load
 
-[src/merklingSession.ts:134-146](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L134-L146 "Source code on GitHub")
-
 ##### Parameters
 
 -   `hash` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | ICid)** 
@@ -298,8 +272,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 Returns **IMerklingProxyState** 
 
 #### save
-
-[src/merklingSession.ts:152-164](https://git@github.com/:kanej/merkling/blob/0cd6bab3be6e4d24f456a58550e6ae5bd73151db/src/merklingSession.ts#L152-L164 "Source code on GitHub")
 
 Save all proxies that are currently marked as dirty,
 and any proxies that depend on them.

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,15 @@
-TODO
-====
+# TODO
 
-* Nested resolving of proxies
-    - Substitute cid to ref on get from ipfs
-* Cleanup type declarations around ICid and cids
-* Throw on accessing data on unloaded proxy
-* Creating nodes with nested IPLD proxies
-* Setting nodes with nested IPLD proxies
-* Recurse flag on get
+- Nested resolving of proxies
+  - Substitute cid to ref on get from ipfs
+- Cleanup type declarations around ICid and cids
+- Throw on accessing data on unloaded proxy
+- Creating nodes with nested IPLD proxies
+- Setting nodes with nested IPLD proxies
+- Recurse flag on get
+
+## Bugs
+
+- [x] Editing child proxy not setting parent proxy to dirty
+- [ ] Example not working in CRA
+- [ ] Issue with arrays

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --fix .\\{src,test}\\**\\*.ts",
     "build": "tsc",
     "dev": "webpack-dev-server --open",
-    "docs-readme": "documentation readme --config documentation.yml --document-exported --section=API --github src/merkling.ts src/merklingSession.ts",
+    "docs-readme": "documentation readme --config documentation.yml --document-exported --section=API src/merkling.ts src/merklingSession.ts",
     "docs": "documentation build --format html --theme node_modules/clean-documentation-theme --o docs",
     "docs-dev": "documentation serve --watch --theme node_modules/clean-documentation-theme",
     "semantic-release": "semantic-release"

--- a/src/internalGraph.ts
+++ b/src/internalGraph.ts
@@ -42,7 +42,7 @@ export default class InternalGraph {
   ancestorsOf(vertex: number): number[] {
     const searchState = this._setupSearchState()
     searchState.unmarked.delete(vertex)
-    searchState.marked.add(vertex)
+
     this._visit(vertex, this._parents, searchState)
     return searchState.l.reverse()
   }

--- a/src/internalGraph.ts
+++ b/src/internalGraph.ts
@@ -7,18 +7,28 @@ interface ISearchState {
 
 export default class InternalGraph {
   private _matrix: Map<number, Set<number>>
+  private _parents: Map<number, Set<number>>
   constructor() {
     this._matrix = new Map<number, Set<number>>()
+    this._parents = new Map<number, Set<number>>()
   }
 
   link(from: number, to: number): void {
-    if (!this._matrix.has(from)) {
-      this._matrix.set(from, new Set<number>())
+    this._populateAdjacencyMapping(this._matrix, from, to)
+    this._populateAdjacencyMapping(this._parents, to, from)
+  }
+
+  _populateAdjacencyMapping(
+    adjacencyMap: Map<number, Set<number>>,
+    from: number,
+    to: number
+  ): void {
+    if (!adjacencyMap.has(from)) {
+      adjacencyMap.set(from, new Set<number>())
     }
 
-    const adjecencyMap = this._matrix.get(from) as Set<number>
-
-    adjecencyMap.add(to)
+    const linkedVertexes = adjacencyMap.get(from) as Set<number>
+    linkedVertexes.add(to)
   }
 
   add(vertex: number): void {
@@ -29,7 +39,53 @@ export default class InternalGraph {
     this._matrix.set(vertex, new Set<number>())
   }
 
+  ancestorsOf(vertex: number): number[] {
+    const searchState = this._setupSearchState()
+    searchState.unmarked.delete(vertex)
+    searchState.marked.add(vertex)
+    this._visit(vertex, this._parents, searchState)
+    return searchState.l.reverse()
+  }
+
   topologicalSort(): number[] {
+    const searchState = this._setupSearchState()
+
+    while (searchState.unmarked.size > 0) {
+      const unmarkedNode = searchState.unmarked.values().next().value
+      searchState.unmarked.delete(unmarkedNode)
+
+      this._visit(unmarkedNode, this._matrix, searchState)
+    }
+
+    return searchState.l
+  }
+
+  private _visit(
+    vertex: number,
+    adjacencyMap: Map<number, Set<number>>,
+    searchState: ISearchState
+  ): void {
+    if (searchState.marked.has(vertex)) {
+      return
+    }
+
+    if (searchState.tempMarked.has(vertex)) {
+      throw new Error('Not a dag')
+    }
+
+    searchState.tempMarked.add(vertex)
+
+    for (const child of adjacencyMap.get(vertex) || new Set<number>()) {
+      this._visit(child, adjacencyMap, searchState)
+    }
+
+    searchState.tempMarked.delete(vertex)
+    searchState.unmarked.delete(vertex)
+    searchState.marked.add(vertex)
+    searchState.l.push(vertex)
+  }
+
+  private _setupSearchState(): ISearchState {
     const allVertexes = new Set<number>(
       Array.from(this._matrix.keys()).concat(
         Array.from(this._matrix.values()).reduce(
@@ -47,34 +103,6 @@ export default class InternalGraph {
       l: [] as number[]
     }
 
-    while (searchState.unmarked.size > 0) {
-      const unmarkedNode = searchState.unmarked.values().next().value
-      searchState.unmarked.delete(unmarkedNode)
-
-      this._visit(unmarkedNode, searchState)
-    }
-
-    return searchState.l
-  }
-
-  private _visit(vertex: number, searchState: ISearchState): void {
-    if (searchState.marked.has(vertex)) {
-      return
-    }
-
-    if (searchState.tempMarked.has(vertex)) {
-      throw new Error('Not a dag')
-    }
-
-    searchState.tempMarked.add(vertex)
-
-    for (const child of this._matrix.get(vertex) || new Set<number>()) {
-      this._visit(child, searchState)
-    }
-
-    searchState.tempMarked.delete(vertex)
-    searchState.unmarked.delete(vertex)
-    searchState.marked.add(vertex)
-    searchState.l.push(vertex)
+    return searchState
   }
 }

--- a/src/merklingProxyHandler.ts
+++ b/src/merklingProxyHandler.ts
@@ -179,6 +179,11 @@ export const merklingProxyHandler: ProxyHandler<IMerklingProxyState> = {
     let proxyId: MerklingProxyRef
     if ('isRef' in value && value.isRef()) {
       proxyId = value as MerklingProxyRef
+
+      target.session._internalGraph.link(
+        target.ref.internalId,
+        proxyId.internalId
+      )
     } else {
       proxyId = new MerklingProxyRef({
         internalId: target.ref.internalId,
@@ -203,6 +208,7 @@ export const merklingProxyHandler: ProxyHandler<IMerklingProxyState> = {
 
     return internalProxy
   },
+
   set(
     target: IMerklingProxyState,
     key: string | number | symbol,
@@ -223,8 +229,7 @@ export const merklingProxyHandler: ProxyHandler<IMerklingProxyState> = {
       record.lifecycleState = MerklingLifecycleState.CLEAN
       return true
     } else {
-      record.lifecycleState = MerklingLifecycleState.DIRTY
-      record.cid = null
+      target.session._markRecordAndAncestorsAsDirty(record.internalId)
 
       if (Merkling.isProxy(value)) {
         if (!Merkling.isIpldNode(value)) {

--- a/test/unit/internalGraph.test.ts
+++ b/test/unit/internalGraph.test.ts
@@ -21,4 +21,29 @@ describe('internal graph', () => {
       expect(g.topologicalSort()).toStrictEqual([4, 3, 1, 2])
     })
   })
+
+  describe('ancestor lookup', () => {
+    it('should provide all ancestors of a vertex', () => {
+      const g = new InternalGraph()
+
+      g.link(1, 2)
+      g.link(2, 3)
+      g.link(2, 4)
+
+      const ancestors = g.ancestorsOf(4)
+      expect(ancestors).toStrictEqual([4, 2, 1])
+    })
+
+    it('should deal with having multiple ancestors of a single node', () => {
+      const g = new InternalGraph()
+
+      g.link(1, 3)
+      g.link(2, 3)
+      g.link(3, 4)
+      g.link(3, 5)
+
+      const ancestors = g.ancestorsOf(5)
+      expect(ancestors).toStrictEqual([5, 3, 2, 1])
+    })
+  })
 })

--- a/test/unit/merklingProxyHandler.test.ts
+++ b/test/unit/merklingProxyHandler.test.ts
@@ -21,7 +21,8 @@ describe('Merkling Proxy Handler', () => {
         _proxies: new Map<string, IMerklingProxyState>(),
         _stateObjToParentRecord: {
           has: () => false
-        }
+        },
+        _markRecordAndAncestorsAsDirty: () => {}
       }
 
       originalState = {
@@ -110,7 +111,8 @@ describe('Merkling Proxy Handler', () => {
         _ipldNodeEntries: new Map<number, IMerklingInternalRecord>(),
         _stateObjToParentRecord: {
           has: () => false
-        }
+        },
+        _markRecordAndAncestorsAsDirty: () => {}
       }
 
       originalState = {


### PR DESCRIPTION
Setting a property on a proxy now sets all its ancestor objects (that are loaded) as dirty. On save
they will all be updated to reflect the change deeper in the graph.